### PR TITLE
Update mysql connector 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .classpath
 .settings
 target
+
+### IDEA ###
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.2.8</version>
+      <version>2.4.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
 		<groupId>mysql</groupId>
 		<artifactId>mysql-connector-java</artifactId>
-		<version>5.1.26</version>
+		<version>8.0.17</version>
 	</dependency>
             
 

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -1,36 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?> 
+<?xml version="1.0" encoding="UTF-8"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence 
-    http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd" 
-    version="1.0"> 
-  
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
+    http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+
     <persistence-unit name="db" transaction-type="RESOURCE_LOCAL">
-    	<provider>org.hibernate.ejb.HibernatePersistence</provider>
-    	
-    	
-    	 
-        <properties> 
-	    <property name="hibernate.archive.autodetection" value="class"/>        
-        
-            <!--property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" /> 
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+
+        <properties>
+            <property name="hibernate.archive.autodetection" value="class"/>
+
+            <!-- <property name="hibernate.connection.driver_class" value="com.mysql.jdbc.Driver" />
             <property name="hibernate.connection.url" value="jdbc:mysql://localhost:3306/prueba" /> 
             <property name="hibernate.connection.username" value="root" /> 
-            <property name="hibernate.connection.password" value="mysql" /--> 
+            <property name="hibernate.connection.password" value="mysql" /> -->
 
-            <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver" /> 
-            <property name="hibernate.connection.url" value="jdbc:hsqldb:mem:app-db" /> 
-            <property name="hibernate.connection.username" value="sa" /> 
-            <property name="hibernate.connection.password" value="" /> 
-            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
+            <property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver"/>
+            <property name="hibernate.connection.url" value="jdbc:hsqldb:mem:app-db"/>
+            <property name="hibernate.connection.username" value="sa"/>
+            <property name="hibernate.connection.password" value=""/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
 
-                            
-            <property name="hibernate.show_sql" value="true" /> 
-            <property name="hibernate.format_sql" value="true" /> 
-            <property name="use_sql_comments" value="true" /> 
-            <property name="hibernate.hbm2ddl.auto" value="update" /> 
+
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="use_sql_comments" value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
         </properties>
-          
-    </persistence-unit> 
-  
+
+    </persistence-unit>
+
 </persistence> 


### PR DESCRIPTION
Mayor:
- Actualiza dependencia `mysql-connector-java`  a version **8.0**

Menor:
- Actualiza dependencia `hsqldb` a **2.4**
- Actualiza version persistence.xml a **2.0**

Test de conexión contra base de datos en memoria y base de datos MySql Server 8  ok.