### PR TITLE
Evitar tener que listar todas las clases en el persistence.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,17 @@
     <testResources>
       <testResource>
         <directory>src/test/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>META-INF/persistence.xml</exclude>
+        </excludes>
+      </testResource>
+      <testResource>
+        <directory>src/test/resources</directory>
         <filtering>true</filtering>
+        <includes>
+          <include>META-INF/persistence.xml</include>
+        </includes>
       </testResource>
     </testResources>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
 
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -7,9 +7,6 @@
   
     <persistence-unit name="db" transaction-type="RESOURCE_LOCAL">
     	<provider>org.hibernate.ejb.HibernatePersistence</provider>
-        <class>utn.dds.persistencia.futbol.persistence.Jugador</class>
-        <class>utn.dds.persistencia.futbol.persistence.Equipo</class>
-        <class>utn.dds.persistencia.futbol.persistence.Formacion</class>
 
         <properties>
 	    <property name="hibernate.archive.autodetection" value="class"/>        

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -7,10 +7,7 @@
 
     <persistence-unit name="db" transaction-type="RESOURCE_LOCAL">
     	  <provider>org.hibernate.ejb.HibernatePersistence</provider>
-        <class>utn.dds.persistencia.futbol.persistence.Jugador</class>
-        <class>utn.dds.persistencia.futbol.persistence.Equipo</class>
-        <class>utn.dds.persistencia.futbol.persistence.Formacion</class>
-        <class>utn.dds.persistencia.futbol.persistence.Partido</class>
+        <jar-file>${project.build.outputDirectory}</jar-file>
         <properties>
 	          <property name="hibernate.archive.autodetection" value="class"/>
         


### PR DESCRIPTION
Recuerdo en su día haber hecho este descubrimiento y me olvidé de compartirlo: no hace falta listar todas las clases en el persistence.xml porque la property `hibernate.archive.autodetection` ya lo hace sola.

El problema está en los tests, que la autodetección no funciona porque solamente busca clases en `test/` y no en `main/`. En un ticket de StackOverflow recuerdo haber encontrado este workaround: agregando algo al pom.xml y una línea en el persistence.xml ya está todo lo necesario para que ande la autodetección y prevenir altos dolores de cabeza 👍🏻 